### PR TITLE
Use TRP3 to boost contrast of unreadable name colors on the main frame

### DIFF
--- a/addon/ui/ListenerFrame.lua
+++ b/addon/ui/ListenerFrame.lua
@@ -471,6 +471,15 @@ function Method:FormatChatMessage( e )
 	
 	-- get icon and name 
 	local name, shortname, icon, color = LibRPNames.Get( e.s, Main.guidmap[e.s] )
+
+	-- let TRP (if it's loaded) boost the contrast of the name color if it's too dark for the selected background
+	if TRP3_API then
+		local classColor = TRP3_API.CreateColorFromHexString(color);
+		local listenerColor = TRP3_API.CreateColor(unpack(self.frameopts.color.bg or self.baseopts.color.bg));
+		local readableColor = TRP3_API.GenerateReadableColor(classColor, listenerColor);
+		color = readableColor:GenerateHexColor();
+	end
+
 	if Main.db.profile.shorten_names then
 		name = shortname
 	end


### PR DESCRIPTION
The default background color is black, which is fine and all - but a some RPers enjoy making their name such a dark color that you can't even read it without changing the background color or trying really hard.

This PR adjusts the color returned from LibRPNames according to the user's TRP3 'contrast level' setting, while also accounting for the chosen background color of the ListenerFrame. If the color is readable already, then no change to the color will be made.

(also this requires users to have TRP3 enabled for the contrast to be boosted, but it's probably a safe bet that most people have TRP3)

also great addon thank you for making it <3