### PR TITLE
Update interface version for WoW 12.0.0

### DIFF
--- a/addon/Listener.toc
+++ b/addon/Listener.toc
@@ -1,4 +1,4 @@
-## Interface: 110207
+## Interface: 120000
 ## Title: Listener
 ## Author: Tammya-MoonGuard
 ## Version: @@addon_version@@


### PR DESCRIPTION
Makes the addon work with WoW 12.0.0. Many people seemed to have applied this fix manually and the addon seems to work fine in 12.0.0 without any other updates.