### PR TITLE
Handle secrets in WoW 12.0.0 and later

### DIFF
--- a/addon/Listener.toc
+++ b/addon/Listener.toc
@@ -1,4 +1,4 @@
-## Interface: 120000
+## Interface: 120000, 120001, 120005
 ## Title: Listener
 ## Author: Tammya-MoonGuard
 ## Version: @@addon_version@@

--- a/addon/src/dmtags.lua
+++ b/addon/src/dmtags.lua
@@ -117,6 +117,7 @@ function Me.HookFrames()
 	while true do
 		frame = EnumerateFrames( frame )
 		if not frame then break end
+		if not canaccessvalue(UnitName( unit )) then break end
 		
 		if frame:IsVisible() and frame:HasScript( "OnClick" ) 
 		   and frame:GetScript( "OnClick" ) == SecureUnitButton_OnClick then

--- a/addon/src/listener.lua
+++ b/addon/src/listener.lua
@@ -429,6 +429,8 @@ end
 --
 function Main:OnSystemMsg( event, message )
 
+	if not canaccessvalue(message) then return end --JK
+
 	do
 		-- check our special patterns to split this event
 		-- into sub events
@@ -478,6 +480,10 @@ end
 function Main:OnChatMsgTextEmote( event, message, sender, language, 
 								  a4, a5, a6, a7, a8, a9, a10, a11, 
 								  guid, a13, a14 )
+
+	if not canaccessallvalues(event, message, sender, language, 
+								  a4, a5, a6, a7, a8, a9, a10, a11, 
+								  guid, a13, a14) then return end
 								  
 	if guid ~= UnitGUID( "player" ) then
 		local realm = message:match( sender .. "%-([A-Za-z0-9']+)" )
@@ -568,6 +574,9 @@ end
 --
 function Main:OnChatMsg( event, message, sender, language, a4, a5, a6, a7, a8, 
                          a9, a10, a11, guid, a13, a14 )
+
+	if not canaccessallvalues(event, message, sender, language, a4, a5, a6, a7, a8, 
+                         a9, a10, a11, guid, a13, a14) then return end
 						 
 	if sender == "" then return end
 

--- a/addon/src/listener.lua
+++ b/addon/src/listener.lua
@@ -394,6 +394,7 @@ function Main.CheckPoke( msg, sender )
 	if loc == "enUS" then
 		-- Currently only supporting english.
 		if msg:find( " you" ) then
+			if not canaccessvalue(UnitName( "target" )) then return end
 			if Main.FullName('target') == sender then return end
 			
 			-- There are a handful of emotes that contain " you" regardless
@@ -929,7 +930,7 @@ function Main.AddChatHistory( sender, event, message, language, guid, channel )
 	end
 	
 	-- if the player's target emotes, then beep+flash
-	if (Main.db.profile.notify_target_sound or Main.db.profile.notify_target_flash)
+	if (Main.db.profile.notify_target_sound or Main.db.profile.notify_target_flash) and canaccessvalue(UnitName( "target" ))
 	   and not Main.Frame.SKIP_BEEP[entry.e]
 	   and Main.frames[2]:EntryFilter( entry ) -- snooper filter
        and Main.FullName("target") == sender

--- a/addon/src/probe.lua
+++ b/addon/src/probe.lua
@@ -54,7 +54,7 @@ function Main.UpdateProbe()
 	end
 	
 	if not UnitIsPlayer( unit ) then unit = nil end
-	if unit then 
+	if unit and canaccessvalue(UnitName( unit )) then
 		unitname = Main.FullName( unit )
 		unitguid = UnitGUID( unit )
 	end

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,6 @@ The game was recently updated to change when addons (like this one) are allowed 
 
 It's not quite ready to use; the original author used Forgepush to stage it for release.
 
-You can still get the fixes by downloading the original [from Curseforge.com](https://www.curseforge.com/wow/addons/listener) and then opening the src folder inside. Download [listener.lua](https://github.com/raptormama/listener/blob/main/addon/src/listener.lua) from this repository and overwrite the file that's already in the folder.
+You can still get the fixes by downloading the original from Curseforge.com and then opening the src folder inside. Download addon/src/listener.lua from this repository and overwrite the file that's already in the folder.
 
 Hopefully it won't be long til an official fix is released.

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,1 @@
-This repository was created to submit a pull request for the Listener addon for World of Warcraft.
-
-The game was recently updated to change when addons (like this one) are allowed to access certain types of data.
-
-It's not quite ready to use; the original author used Forgepush to stage it for release.
-
-You can still get the fixes by downloading the original from Curseforge.com and then opening the src folder inside. Download addon/src/listener.lua from this repository and overwrite the file that's already in the folder.
-
-Hopefully it won't be long til an official fix is released.
+This addon is designed to keep your brain from melting, at least in one way: it lets you view the chat (and other channel) messages from the targeted or moused-over player. It's especially useful in very busy situations!

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,9 @@
-to build, checkout forgepush
+This repository was created to submit a pull request for the Listener addon for World of Warcraft.
 
-PS C:\repos\listener> py ..\forgepush\forgepush.py
-Cleanup...
-Copying exports.
-Post-processing files.
+The game was recently updated to change when addons (like this one) are allowed to access certain types of data.
 
-.forgepush now contains the staged addon folder
+It's not quite ready to use; the original author used Forgepush to stage it for release.
+
+You can still get the fixes by downloading the original [from Curseforge.com](https://www.curseforge.com/wow/addons/listener) and then opening the src folder inside. Download [listener.lua](https://github.com/raptormama/listener/blob/main/addon/src/listener.lua) from this repository and overwrite the file that's already in the folder.
+
+Hopefully it won't be long til an official fix is released.


### PR DESCRIPTION
This code revision adds handlers for secrets. AddOns can't access chat in some situations in Midnight and later, so Listener throws errors when it tries.

With these changes, Listener won't try to process messages while they or any related variables are secret.