### PR TITLE
Re-Fixing TRP NPC/DM Tags

### DIFF
--- a/addon/Listener.toc
+++ b/addon/Listener.toc
@@ -1,4 +1,4 @@
-## Interface: 120000
+## Interface: 120000, 120001, 120005
 ## Title: Listener
 ## Author: Tammya-MoonGuard
 ## Version: @@addon_version@@

--- a/addon/src/dmtags.lua
+++ b/addon/src/dmtags.lua
@@ -117,6 +117,7 @@ function Me.HookFrames()
 	while true do
 		frame = EnumerateFrames( frame )
 		if not frame then break end
+		if not canaccessvalue(UnitName( unit )) then break end
 		
 		if frame:IsVisible() and frame:HasScript( "OnClick" ) 
 		   and frame:GetScript( "OnClick" ) == SecureUnitButton_OnClick then

--- a/addon/src/dmtags.lua
+++ b/addon/src/dmtags.lua
@@ -117,13 +117,12 @@ function Me.HookFrames()
 	while true do
 		frame = EnumerateFrames( frame )
 		if not frame then break end
-		if not canaccessvalue(UnitName( unit )) then break end
 		
 		if frame:IsVisible() and frame:HasScript( "OnClick" ) 
 		   and frame:GetScript( "OnClick" ) == SecureUnitButton_OnClick then
 		   
 			local unit = frame:GetAttribute( "unit" )
-			if unit then
+			if unit and canaccessvalue(UnitName( unit )) then
 				if unit:match( "raid[0-9]+" ) or unit:match( "party[1-9]" ) then
 					local name = Main.FullName( unit )
 					

--- a/addon/src/dmtags.lua
+++ b/addon/src/dmtags.lua
@@ -87,6 +87,25 @@ function Me.LoadFont()
 end
 
 -------------------------------------------------------------------------------
+-- Safely test values returned by secure/protected UI APIs.
+--
+-- Newer WoW clients can return "secret" values from protected frames when an
+-- addon has tainted execution. Directly testing those values, e.g.
+-- `if frame:IsVisible() then`, can raise "attempt to perform boolean test on a
+-- secret boolean value". Guard all such tests with canaccessvalue first.
+--
+local function IsAccessible( value )
+	if type( canaccessvalue ) == "function" then
+		return canaccessvalue( value )
+	end
+	return true
+end
+
+local function SafeTruthy( value )
+	return IsAccessible( value ) and value
+end
+
+-------------------------------------------------------------------------------
 -- Enable/disable DM Tags.
 --
 function Me.Enable( enabled )
@@ -113,45 +132,37 @@ function Me.HookFrames()
 	local frame = nil
 	
 	local list = {}
-
-	local function SafeCall( object, method, ... )
-		if not object or not object[method] then return nil end
-		local ok, value = pcall( object[method], object, ... )
-		if not ok or not canaccessvalue( value ) then return nil end
-		return value
-	end
 	
 	while true do
 		frame = EnumerateFrames( frame )
 		if not frame then break end
 		
-		local visible = SafeCall( frame, "IsVisible" )
-		local has_click = SafeCall( frame, "HasScript", "OnClick" )
-		local onclick = nil
-		if has_click then
-			onclick = SafeCall( frame, "GetScript", "OnClick" )
-		end
-
-		if visible and has_click and onclick == SecureUnitButton_OnClick then
-		   
-			local unit = SafeCall( frame, "GetAttribute", "unit" )
-			if type( unit ) == "string" and canaccessvalue( UnitName( unit ) ) then
-				if unit:match( "raid[0-9]+" ) or unit:match( "party[1-9]" ) then
-					local name = Main.FullName( unit )
-					
-					if name then
-						if not list[name] then
-							list[name] = {
-								frames = {}
-							}
-						end
+		local visible = frame:IsVisible()
+		local has_onclick = frame:HasScript( "OnClick" )
+		
+		if SafeTruthy( visible ) and SafeTruthy( has_onclick ) then
+			local onclick = frame:GetScript( "OnClick" )
+			
+			if IsAccessible( onclick ) and onclick == SecureUnitButton_OnClick then
+				local unit = frame:GetAttribute( "unit" )
+				
+				if SafeTruthy( unit ) and IsAccessible( UnitName( unit ) ) then
+					if unit:match( "raid[0-9]+" ) or unit:match( "party[1-9]" ) then
+						local name = Main.FullName( unit )
 						
-						table.insert( list[name].frames, frame )
+						if name then
+							if not list[name] then
+								list[name] = {
+									frames = {}
+								}
+							end
+							
+							table.insert( list[name].frames, frame )
+						end
 					end
 				end
+				--thanks Semler!
 			end
-			--thanks Semler!
-			
 		end
 	end
 	

--- a/addon/src/dmtags.lua
+++ b/addon/src/dmtags.lua
@@ -113,16 +113,29 @@ function Me.HookFrames()
 	local frame = nil
 	
 	local list = {}
+
+	local function SafeCall( object, method, ... )
+		if not object or not object[method] then return nil end
+		local ok, value = pcall( object[method], object, ... )
+		if not ok or not canaccessvalue( value ) then return nil end
+		return value
+	end
 	
 	while true do
 		frame = EnumerateFrames( frame )
 		if not frame then break end
 		
-		if frame:IsVisible() and frame:HasScript( "OnClick" ) 
-		   and frame:GetScript( "OnClick" ) == SecureUnitButton_OnClick then
+		local visible = SafeCall( frame, "IsVisible" )
+		local has_click = SafeCall( frame, "HasScript", "OnClick" )
+		local onclick = nil
+		if has_click then
+			onclick = SafeCall( frame, "GetScript", "OnClick" )
+		end
+
+		if visible and has_click and onclick == SecureUnitButton_OnClick then
 		   
-			local unit = frame:GetAttribute( "unit" )
-			if unit and canaccessvalue(UnitName( unit )) then
+			local unit = SafeCall( frame, "GetAttribute", "unit" )
+			if type( unit ) == "string" and canaccessvalue( UnitName( unit ) ) then
 				if unit:match( "raid[0-9]+" ) or unit:match( "party[1-9]" ) then
 					local name = Main.FullName( unit )
 					

--- a/addon/src/listener.lua
+++ b/addon/src/listener.lua
@@ -429,6 +429,8 @@ end
 --
 function Main:OnSystemMsg( event, message )
 
+	if not canaccessvalue(message) then return end --JK
+
 	do
 		-- check our special patterns to split this event
 		-- into sub events
@@ -478,6 +480,10 @@ end
 function Main:OnChatMsgTextEmote( event, message, sender, language, 
 								  a4, a5, a6, a7, a8, a9, a10, a11, 
 								  guid, a13, a14 )
+
+	if not canaccessallvalues(event, message, sender, language, 
+								  a4, a5, a6, a7, a8, a9, a10, a11, 
+								  guid, a13, a14) then return end
 								  
 	if guid ~= UnitGUID( "player" ) then
 		local realm = message:match( sender .. "%-([A-Za-z0-9']+)" )
@@ -568,6 +574,9 @@ end
 --
 function Main:OnChatMsg( event, message, sender, language, a4, a5, a6, a7, a8, 
                          a9, a10, a11, guid, a13, a14 )
+
+	if not canaccessallvalues(event, message, sender, language, a4, a5, a6, a7, a8, 
+                         a9, a10, a11, guid, a13, a14) then return end
 						 
 	if sender == "" then return end
 

--- a/addon/src/listener.lua
+++ b/addon/src/listener.lua
@@ -394,6 +394,7 @@ function Main.CheckPoke( msg, sender )
 	if loc == "enUS" then
 		-- Currently only supporting english.
 		if msg:find( " you" ) then
+			if not canaccessvalue(UnitName( "target" )) then return end
 			if Main.FullName('target') == sender then return end
 			
 			-- There are a handful of emotes that contain " you" regardless
@@ -929,7 +930,7 @@ function Main.AddChatHistory( sender, event, message, language, guid, channel )
 	end
 	
 	-- if the player's target emotes, then beep+flash
-	if (Main.db.profile.notify_target_sound or Main.db.profile.notify_target_flash)
+	if (Main.db.profile.notify_target_sound or Main.db.profile.notify_target_flash) and canaccessvalue(UnitName( "target" ))
 	   and not Main.Frame.SKIP_BEEP[entry.e]
 	   and Main.frames[2]:EntryFilter( entry ) -- snooper filter
        and Main.FullName("target") == sender

--- a/addon/src/listener.lua
+++ b/addon/src/listener.lua
@@ -99,6 +99,17 @@ local function GetTRPNPCMessageName( lineID )
 	end
 end
 
+local function GetTRPOwnershipEmotePrefix( lineID )
+	if lineID == nil then return nil end
+
+	local trp = _G.TRP3_API
+	if not trp or not trp.chat or not trp.chat.getOwnershipNameID then return nil end
+
+	if trp.chat.getOwnershipNameID() == lineID then
+		return "'s "
+	end
+end
+
 local function GetTRPNPCTalkPatterns()
 	local patterns = {}
 	local trp = _G.TRP3_API
@@ -827,6 +838,15 @@ function Main:OnChatMsg( event, message, sender, language, a4, a5, a6, a7, a8,
 		return
 	end	
 	
+	local originalEmotePrefix
+	if event == "EMOTE" then
+		if message:sub(1, 3) == "'s " then
+			originalEmotePrefix = "'s "
+		elseif message:sub(1, 2) == ", " then
+			originalEmotePrefix = ", "
+		end
+	end
+	
 	if filters then -- in a rare case with very little addons, the filter
 	                -- list may actually be nil
 					
@@ -866,6 +886,16 @@ function Main:OnChatMsg( event, message, sender, language, a4, a5, a6, a7, a8,
 				end
 			end
 		end
+	end
+
+	-- TRP3 removes leading "'s " from emotes and records the line ID so its
+	-- name formatter can append the suffix directly to the displayed name.
+	-- Listener renders from its own stored message instead, so restore the
+	-- prefix from TRP3's public line-ID flag when Listener receives the already
+	-- filtered message.
+	local trpEmotePrefix = originalEmotePrefix or GetTRPOwnershipEmotePrefix( a11 )
+	if event == "EMOTE" and trpEmotePrefix and message:sub(1, #trpEmotePrefix) ~= trpEmotePrefix then
+		message = trpEmotePrefix .. message
 	end
 	
 	local dm_info

--- a/addon/src/listener.lua
+++ b/addon/src/listener.lua
@@ -33,6 +33,240 @@ local IGNORED_CHANNELS = {
 	xtensionxtooltip2 = true -- Common addon channel.
 }
 
+
+local function TrimString( value )
+	if strtrim then return strtrim( value ) end
+	return (value:gsub( "^%s+", "" ):gsub( "%s+$", "" ))
+end
+
+local function GetShortNPCName( name )
+	local short = name and name:match( "%S+" )
+	if short and #short >= 4 then return short end
+	return name
+end
+
+function Main.NormalizeIconPath( icon )
+	if icon == nil or icon == "" then return nil end
+
+	local iconType = type( icon )
+	if iconType == "number" then return icon end
+	if iconType ~= "string" then return nil end
+
+	icon = icon:match( "^|T([^:|]+)" ) or icon
+	icon = icon:gsub( "^Interface[\\/][Ii][Cc][Oo][Nn][Ss][\\/]", "" )
+	if icon == "" then return nil end
+
+	return icon
+end
+
+function Main.FormatIconMarkup( icon, zoom )
+	icon = Main.NormalizeIconPath( icon )
+	if not icon then return "" end
+
+	local texture = tostring( icon )
+	if type( icon ) ~= "number" and not texture:match( "^%d+$" ) and not texture:lower():match( "^interface[\\/]" ) then
+		texture = "Interface\\Icons\\" .. texture
+	end
+
+	if zoom then
+		return "|T" .. texture .. ":0:0:0:0:100:100:10:90:10:90:255:255:255|t "
+	end
+
+	return "|T" .. texture .. ":0|t "
+end
+
+function Main.StripPipeEmotePrefix( message )
+	if type( message ) ~= "string" then return nil end
+
+	if message:sub( 1, 2 ) == "| " then
+		return message:sub( 3 )
+	end
+
+	return nil
+end
+
+local function GetTRPNPCMessageName( lineID )
+	if lineID == nil then return nil end
+
+	local trp = _G.TRP3_API
+	if not trp or not trp.chat then return nil end
+	if not trp.chat.getNPCMessageID or not trp.chat.getNPCMessageName then return nil end
+	if trp.chat.getNPCMessageID() ~= lineID then return nil end
+
+	local replacement = trp.chat.getNPCMessageName()
+	if type( replacement ) == "string" and replacement ~= "" then
+		return replacement
+	end
+end
+
+local function GetTRPNPCTalkPatterns()
+	local patterns = {}
+	local trp = _G.TRP3_API
+	local loc = trp and trp.loc
+
+	local function add( pattern )
+		if type( pattern ) == "string" and pattern ~= "" then
+			patterns[pattern] = true
+		end
+	end
+
+	if loc then
+		add( loc.NPC_TALK_SAY_PATTERN )
+		add( loc.NPC_TALK_YELL_PATTERN )
+		add( loc.NPC_TALK_WHISPER_PATTERN )
+	end
+
+	add( "says:" )
+	add( "yells:" )
+	add( "whispers:" )
+
+	return patterns
+end
+
+local function MatchTRPNPCSpeech( message )
+	if type( message ) ~= "string" then return nil end
+
+	for talkType in pairs( GetTRPNPCTalkPatterns() ) do
+		local start = message:find( talkType, 1, true )
+		while start do
+			if start > 2 and message:sub( start - 1, start - 1 ):match( "%s" ) then
+				local name = TrimString( message:sub( 1, start - 2 ) )
+				if name ~= "" then
+					return name, message:sub( start )
+				end
+			end
+			start = message:find( talkType, start + 1, true )
+		end
+	end
+end
+
+local function GetProfileNPCInfo( profile, fallbackName )
+	local data = profile and profile.data
+	if not data then return nil end
+
+	local name = data.NA or fallbackName
+	local icon = Main.NormalizeIconPath( data.IC )
+	local color = data.NH
+
+	if color and color ~= "" then
+		color = "ff" .. color
+	else
+		color = nil
+	end
+
+	return name, GetShortNPCName( name ), icon, color
+end
+
+local function ResolveTRPNPCSpeaker( rawName, senderID )
+	rawName = TrimString( rawName or "" )
+	local bracketName = rawName:match( "^%[(.-)%]$" )
+
+	if not bracketName then
+		return rawName, GetShortNPCName( rawName )
+	end
+
+	local trp = _G.TRP3_API
+	local companions = trp and trp.companions
+
+	if companions and companions.player and companions.player.getProfiles then
+		for _, profile in pairs( companions.player.getProfiles() ) do
+			if profile.data and profile.data.NA == bracketName then
+				return GetProfileNPCInfo( profile, bracketName )
+			end
+		end
+	end
+
+	if companions and companions.register and companions.register.getProfiles then
+		for _, profile in pairs( companions.register.getProfiles() ) do
+			local isMaster = not senderID
+			if not isMaster and profile.links and trp and trp.utils and trp.utils.str and trp.utils.str.companionIDToInfo then
+				for companionFullID, _ in pairs( profile.links ) do
+					if trp.utils.str.companionIDToInfo( companionFullID ) == senderID then
+						isMaster = true
+						break
+					end
+				end
+			end
+			if isMaster and profile.data and profile.data.NA == bracketName then
+				return GetProfileNPCInfo( profile, bracketName )
+			end
+		end
+	end
+
+	return bracketName, GetShortNPCName( bracketName )
+end
+
+local function ParseTRPFormattedSpeaker( formattedName )
+	if type( formattedName ) ~= "string" then return nil end
+
+	local icon = Main.NormalizeIconPath( formattedName:match( "|T([^:|]+)" ) )
+	local color = formattedName:match( "|c(%x%x%x%x%x%x%x%x)" )
+	local name = formattedName:gsub( "|T.-|t%s*", "" )
+	name = name:gsub( "|c%x%x%x%x%x%x%x%x", "" )
+	name = name:gsub( "|r", "" )
+	name = TrimString( name )
+
+	if name == "" then return nil end
+	return name, GetShortNPCName( name ), icon, color
+end
+
+function Main.GetPipeEmoteInfo( message, senderID )
+	local body = Main.StripPipeEmotePrefix( message )
+	if body == nil then return nil end
+
+	local info = {
+		message = body;
+		anonymous = true;
+	}
+
+	local speaker, speech = MatchTRPNPCSpeech( body )
+	if speaker and speech then
+		local name, shortname, icon, color = ResolveTRPNPCSpeaker( speaker, senderID )
+		info.message = speech
+		info.anonymous = nil
+		info.name = name
+		info.shortname = shortname
+		info.icon = icon
+		info.color = color
+	end
+
+	return info
+end
+
+function Main.GetTRPNPCMessageInfo( message, lineID )
+	local replacement = GetTRPNPCMessageName( lineID )
+	if not replacement then return nil end
+
+	if message == " " then
+		return Main.GetPipeEmoteInfo( "| " .. replacement ) or {
+			message = replacement;
+			anonymous = true;
+		}
+	end
+
+	local name, shortname, icon, color = ParseTRPFormattedSpeaker( replacement )
+	if not name then return nil end
+
+	return {
+		message = message;
+		name = name;
+		shortname = shortname;
+		icon = icon;
+		color = color;
+	}
+end
+
+function Main.RecoverTRPPipeEmote( message, lineID )
+	if message ~= " " then return message end
+
+	local replacement = GetTRPNPCMessageName( lineID )
+	if replacement then
+		return "| " .. replacement
+	end
+
+	return message
+end
+
 -------------------------------------------------------------------------------
 -- The following is some serious mojo to convert localized strings into
 -- matching patterns. A feeble attempt at providing message recognition that
@@ -584,6 +818,10 @@ function Main:OnChatMsg( event, message, sender, language, a4, a5, a6, a7, a8,
 	local filters = ChatFrameUtil and ChatFrameUtil.GetMessageEventFilters(event) or ChatFrame_GetMessageEventFilters(event)
 	event = event:sub( 10 )
 	
+	if event == "EMOTE" then
+		message = Main.RecoverTRPPipeEmote( message, a11 )
+	end
+	
 	if event:find( "CHANNEL" ) and IGNORED_CHANNELS[a9:lower()] then
 		-- this channel is ignored and not logged.
 		return
@@ -594,7 +832,7 @@ function Main:OnChatMsg( event, message, sender, language, a4, a5, a6, a7, a8,
 					
 		local skipfilters = false
 
-		if message:sub(1,3) == "|| " then
+		if event == "EMOTE" and Main.StripPipeEmotePrefix( message ) ~= nil then
 			-- trp hack for npc emotes
 			skipfilters = true
 		elseif message:sub(1,2) == "'s" and event == "EMOTE" then
@@ -630,7 +868,18 @@ function Main:OnChatMsg( event, message, sender, language, a4, a5, a6, a7, a8,
 		end
 	end
 	
-	Main.AddChatHistory( sender, event, message, language, guid, a9 )
+	local dm_info
+	if event == "EMOTE" then
+		message = Main.RecoverTRPPipeEmote( message, a11 )
+		if Main.db.profile.trp_emotes then
+			dm_info = Main.GetPipeEmoteInfo( message, sender ) or Main.GetTRPNPCMessageInfo( message, a11 )
+			if dm_info then
+				message = dm_info.message
+			end
+		end
+	end
+	
+	Main.AddChatHistory( sender, event, message, language, guid, a9, dm_info )
 end
 
 -------------------------------------------------------------------------------
@@ -790,7 +1039,7 @@ end
 -- This adds a chat event into the chat history.
 --
 -- A lot of stuff happens in here . . .
-function Main.AddChatHistory( sender, event, message, language, guid, channel )
+function Main.AddChatHistory( sender, event, message, language, guid, channel, dm_info )
 	
 	-- discard empty messages (unless the event doesn't have a message).
 	if message == "" and (event ~= "CHANNEL_JOIN" and event ~= "CHANNEL_LEAVE") then return end
@@ -813,6 +1062,9 @@ function Main.AddChatHistory( sender, event, message, language, guid, channel )
 	Main._history_dedupe = Main._history_dedupe or {}
 	local now = GetTime()
 	local key = (event or "") .. "|" .. (sender or "") .. "|" .. (message or "")
+	if dm_info and dm_info.name then
+		key = key .. "|" .. dm_info.name
+	end
 	local last = Main._history_dedupe[key]
 	if last and now - last < 0.5 then
 		return
@@ -893,6 +1145,14 @@ function Main.AddChatHistory( sender, event, message, language, guid, channel )
 		s  = sender;
 		r  = true;              -- unread
 	}
+	
+	if dm_info then
+		entry.dma = dm_info.anonymous
+		entry.dmn = dm_info.name
+		entry.dms = dm_info.shortname
+		entry.dmi = dm_info.icon
+		entry.dmc = dm_info.color
+	end
 	
 	if event:find( "CHANNEL" ) then
 		if not channel then return end

--- a/addon/src/probe.lua
+++ b/addon/src/probe.lua
@@ -54,7 +54,7 @@ function Main.UpdateProbe()
 	end
 	
 	if not UnitIsPlayer( unit ) then unit = nil end
-	if unit then 
+	if unit and canaccessvalue(UnitName( unit )) then
 		unitname = Main.FullName( unit )
 		unitguid = UnitGUID( unit )
 	end

--- a/addon/src/snoop2.lua
+++ b/addon/src/snoop2.lua
@@ -192,6 +192,9 @@ local MESSAGE_PREFIXES = {
 --
 local function MsgFormatNormal( e, name )
 	local prefix = MESSAGE_PREFIXES[e.e] or ""
+	if e.dmn then
+		return prefix .. name .. " " .. e.m
+	end
 	if e.e == "CHANNEL" then
 		local index = GetChannelName( e.c )
 		if index ~= 0 then
@@ -220,18 +223,23 @@ end
 -- No separator between name and text.
 --
 local function MsgFormatEmote( e, name )
+	if e.dmn then
+		return name .. " " .. e.m
+	end
+	if e.dma then
+		return e.m
+	end
 	-- If they prefix with a pipe, cut off the name and remove the pipes.
 	-- Note that this is specially different from the main window.
 	-- The name is implied in the snooper window, so we don't need 
 	-- to check against the trp_emotes option.
-	-- It's common to prefix with "|" or "||" in emotes to denote that your
+	-- It's common to prefix with "| " in emotes to denote that your
 	-- emote should not consider the name before it.
 	--
-	-- And, pipes are doubled up, because they're wow's escape character.
-	--
-	if e.m:match( "^||" ) then
-		-- cut off pipes and trailing space.
-		return e.m:match( "^|+%s*(.*)" )
+	local pipe_emote = Main.StripPipeEmotePrefix( e.m )
+	if pipe_emote ~= nil then
+		-- cut off pipe and trailing space.
+		return pipe_emote
 	end
 	
 	-- 
@@ -251,6 +259,9 @@ end
 -- <name> <msg> - name is substituted
 --
 local function MsgFormatTextEmote( e, name )
+	if e.dmn then
+		return name .. " " .. e.m
+	end
 	-- Need to convert - to %- to avoid it triggering a pattern and
 	--  invalidating the name match.
 	local msg = e.m:gsub( e.s:gsub("%-","%%-"), name )
@@ -336,16 +347,22 @@ function Me:FormatChatMessage( e )
 	
 	stamp = timecolor .. stamp .. "|r "
 	
-	local name, shortname, _, color = LibRPNames.Get( e.s, Main.guidmap[e.s] )
+	local custom_speaker = e.dmn ~= nil
+	local name, shortname, color
+	if custom_speaker then
+		name, shortname, color = e.dmn, e.dms or e.dmn, e.dmc
+	else
+		name, shortname, _, color = LibRPNames.Get( e.s, Main.guidmap[e.s] )
+	end
 	if Main.db.profile.shorten_names then
 		name = shortname
 	end
 	
-	if color and self.frameopts.name_colors then
+	if color and (custom_speaker or self.frameopts.name_colors) then
 		name = "|c" .. color .. name .. "|r"
 	end
 	
-	if self.frameopts.enable_mouse then
+	if self.frameopts.enable_mouse and not custom_speaker then
 		-- we only make links for players when the mouse is enabled.
 		name = "|Hplayer:" .. e.s .. "|h" .. name .. "|h"
 	end

--- a/addon/ui/ListenerFrame.lua
+++ b/addon/ui/ListenerFrame.lua
@@ -353,6 +353,9 @@ local TIMESTAMP = {
 -- Normal "name: text"
 local function MsgFormatNormal( e, name )
 	local prefix = MSG_FORMAT_PREFIX[e.e] or ""
+	if e.dmn then
+		return prefix .. name .. " " .. e.m
+	end
 	return prefix .. name .. ": " .. e.m
 end
 
@@ -384,8 +387,15 @@ end
 -------------------------------------------------------------------------------
 -- No separator between name and text.
 local function MsgFormatEmote( e, name )
-	if Main.db.profile.trp_emotes and e.m:sub(1,3) == "|| " then
-		return e.m:sub( 4 )
+	if e.dmn then
+		return name .. " " .. e.m
+	end
+	if e.dma then
+		return e.m
+	end
+	local pipe_emote = Main.StripPipeEmotePrefix( e.m )
+	if Main.db.profile.trp_emotes and pipe_emote ~= nil then
+		return pipe_emote
 	end
 	if e.m:sub( 1,2 ) == ", " or e.m:sub( 1,2 ) == "'s" then
 		return name .. e.m
@@ -396,6 +406,9 @@ end
 -------------------------------------------------------------------------------
 -- <name> <msg> - name is substituted
 local function MsgFormatTextEmote( e, name )
+	if e.dmn then
+		return name .. " " .. e.m
+	end
 	if e.s == "" then return e.m end -- Some dumb global emote by bosses.
 	
 	-- Need to convert - to %- to avoid it triggering a pattern and
@@ -469,13 +482,19 @@ function Method:FormatChatMessage( e )
 		stamp = "|cff808080" .. TIMESTAMP[ts](e.t) .. "|r" 
 	end
 	
-	-- get icon and name 
-	local name, shortname, icon, color = LibRPNames.Get( e.s, Main.guidmap[e.s] )
+	local custom_speaker = e.dmn ~= nil
+	local anonymous_speaker = e.dma ~= nil
+	local name, shortname, icon, color
+	if custom_speaker then
+		name, shortname, icon, color = e.dmn, e.dms or e.dmn, e.dmi, e.dmc
+	else
+		name, shortname, icon, color = LibRPNames.Get( e.s, Main.guidmap[e.s] )
+	end
 	if Main.db.profile.shorten_names then
 		name = shortname
 	end
 	
-	if not icon then
+	if not icon and not custom_speaker and not anonymous_speaker then
 		local alliance = UnitFactionGroup( "player" ) == "Alliance"
 		if e.h then
 			alliance = not alliance
@@ -488,11 +507,7 @@ function Method:FormatChatMessage( e )
 	end
 	
 	if icon and Main.db.profile.frame.show_icons then
-		if Main.db.profile.frame.zoom_icons then
-			icon = "|TInterface\\Icons\\" .. icon .. ":0:0:0:0:100:100:10:90:10:90:255:255:255|t "
-		else
-			icon = "|TInterface\\Icons\\" .. icon .. ":0|t "
-		end
+		icon = Main.FormatIconMarkup( icon, Main.db.profile.frame.zoom_icons )
 	else
 		icon = ""
 	end
@@ -501,7 +516,9 @@ function Method:FormatChatMessage( e )
 		name = "|c" .. color .. name .. "|r"
 	end
 	
-	name = "|Hplayer:" .. e.s .. "|h" .. name .. "|h" 
+	if not custom_speaker and not anonymous_speaker then
+		name = "|Hplayer:" .. e.s .. "|h" .. name .. "|h" 
+	end
 	
 	return string.format( "%s%s%s", stamp, icon, MSG_FORMAT_FUNCTIONS[e.e]( e, name ) )
 end

--- a/readme.txt
+++ b/readme.txt
@@ -4,6 +4,6 @@ The game was recently updated to change when addons (like this one) are allowed 
 
 It's not quite ready to use; the original author used Forgepush to stage it for release.
 
-You can still get the fixes by downloading the original [from Curseforge.com](https://www.curseforge.com/wow/addons/listener) and then opening the src folder inside. Download [listener.lua](https://github.com/raptormama/listener/blob/main/addon/src/listener.lua) from this repository and overwrite the file that's already in the folder.
+You can still get the fixes by downloading the original from Curseforge.com and then opening the src folder inside. Download addon/src/listener.lua from this repository and overwrite the file that's already in the folder.
 
 Hopefully it won't be long til an official fix is released.

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,1 @@
-This repository was created to submit a pull request for the Listener addon for World of Warcraft.
-
-The game was recently updated to change when addons (like this one) are allowed to access certain types of data.
-
-It's not quite ready to use; the original author used Forgepush to stage it for release.
-
-You can still get the fixes by downloading the original from Curseforge.com and then opening the src folder inside. Download addon/src/listener.lua from this repository and overwrite the file that's already in the folder.
-
-Hopefully it won't be long til an official fix is released.
+This addon is designed to keep your brain from melting, at least in one way: it lets you view the chat (and other channel) messages from the targeted or moused-over player. It's especially useful in very busy situations!

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,9 @@
-to build, checkout forgepush
+This repository was created to submit a pull request for the Listener addon for World of Warcraft.
 
-PS C:\repos\listener> py ..\forgepush\forgepush.py
-Cleanup...
-Copying exports.
-Post-processing files.
+The game was recently updated to change when addons (like this one) are allowed to access certain types of data.
 
-.forgepush now contains the staged addon folder
+It's not quite ready to use; the original author used Forgepush to stage it for release.
+
+You can still get the fixes by downloading the original [from Curseforge.com](https://www.curseforge.com/wow/addons/listener) and then opening the src folder inside. Download [listener.lua](https://github.com/raptormama/listener/blob/main/addon/src/listener.lua) from this repository and overwrite the file that's already in the folder.
+
+Hopefully it won't be long til an official fix is released.


### PR DESCRIPTION
Downstream of raptormama's commit, necessarily, since it hasn't been merged yet and I ain't rewriting all that
Did a cursory inspection and it didn't look suspicious, so that's my base now
This is incredibly hacky garbage code that almost certainly can be improved but it works on my machine, and it'll have to do until we get an official update. May I cordially invite you to show me up in every way

Anyway;
providence note for https://github.com/raptormama/listener and their 12.0.5 sanitation efforts
src/listener.lua

Added TRP3 NPC message detection and parsing.
Added recovery of NPC speaker names from TRP3 APIs.
Added support for storing NPC display metadata (name, short name, icon, color).
Added handling for anonymous (| ) emotes. (also nuked old formatting)
Added helper functions for NPC name/icon formatting.
Improved compatibility with TRP3 companion profiles.

ui/ListenerFrame.lua

Display NPC speakers using their NPC names instead of player names.
Show custom NPC icons and colors.
Prevent NPC names from being rendered as clickable player links.
Improve display of anonymous emotes.
Use stored NPC metadata when rendering chat history.

src/snoop2.lua

Apply NPC speaker support to Snooper windows.
Apply anonymous-emote handling to Snooper windows.
Prevent NPC names from becoming clickable player links.
Support custom NPC colors in Snooper displays.
Keep Snooper presentation consistent with the main Listener window.

<img width="514" height="293" alt="image" src="https://github.com/user-attachments/assets/0fb6b4e7-dba2-4388-b68d-7dfc8eb6f8ae" />
<img width="281" height="421" alt="image" src="https://github.com/user-attachments/assets/33304040-e219-4216-a4f3-0f5ea8937b42" />

